### PR TITLE
Modify scripts to enable minifying during create-react-app build

### DIFF
--- a/extcrypto/index.js
+++ b/extcrypto/index.js
@@ -1,1 +1,1 @@
-exports = module.exports = require('../build/Release/extcrypto_addon');
+exports = module.exports = require('../build/Release/extcrypto_addon.node');

--- a/lib/decapsulate.js
+++ b/lib/decapsulate.js
@@ -1,5 +1,8 @@
-const utils = require('./utils');
+'use strict';
 
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var utils = require('./utils');
 
 /***
  * hvalidate
@@ -14,16 +17,17 @@ const utils = require('./utils');
  * @returns {String} token
  */
 function hvalidate(token, header) {
-  const parsed = Buffer.from(token, 'utf-8');
+  var parsed = Buffer.from(token, 'utf-8');
 
-  const hlen    = Buffer.byteLength(header);
-  const leading = parsed.slice(0, hlen);
+  var hlen = Buffer.byteLength(header);
+  var leading = parsed.slice(0, hlen);
 
-  if (!utils.cnstcomp(header, leading)) { throw new Error('Invalid message header'); }
+  if (!utils.cnstcomp(header, leading)) {
+    throw new Error('Invalid message header');
+  }
 
   return parsed.slice(hlen).toString('utf-8');
 }
-
 
 /***
  * extract
@@ -37,13 +41,10 @@ function hvalidate(token, header) {
  * @returns {Buffer} footer
  */
 function extract(token) {
-  const pieces = token.split('.');
+  var pieces = token.split('.');
 
-  return (pieces.length > 3)
-    ? utils.fromB64URLSafe(pieces.pop())
-    : Buffer.from('');
+  return pieces.length > 3 ? utils.fromB64URLSafe(pieces.pop()) : Buffer.from('');
 };
-
 
 /***
  * remove
@@ -57,13 +58,10 @@ function extract(token) {
  * @returns {String} token
  */
 function remove(token) {
-  const pieces = token.split('.');
+  var pieces = token.split('.');
 
-  return (pieces.length > 3)
-    ? pieces.slice(0, 3).join('.')
-    : token;
+  return pieces.length > 3 ? pieces.slice(0, 3).join('.') : token;
 };
-
 
 /***
  * fvalidate
@@ -78,16 +76,19 @@ function remove(token) {
  * @returns {String} token
  */
 function fvalidate(token, footer) {
-  if (!footer) { return token; }
-  footer = Buffer.concat([ Buffer.from('.', 'utf-8'), footer ]);
+  if (!footer) {
+    return token;
+  }
+  footer = Buffer.concat([Buffer.from('.', 'utf-8'), footer]);
 
-  const trailing = Buffer.concat([ Buffer.from('.', 'utf-8'), extract(token) ]);
+  var trailing = Buffer.concat([Buffer.from('.', 'utf-8'), extract(token)]);
 
-  if (!utils.cnstcomp(footer, trailing)) { throw new Error('Invalid message footer'); }
+  if (!utils.cnstcomp(footer, trailing)) {
+    throw new Error('Invalid message footer');
+  }
 
   return remove(token);
 }
-
 
 /***
  * decapsulate
@@ -103,14 +104,25 @@ module.exports = decapsulate;
 function decapsulate(header, token, footer) {
   if (!footer) {
     footer = extract(token);
-    token  = remove(token);
+    token = remove(token);
   } else {
-    [ footer ] = (utils.parse('utf-8'))(footer);
-    token      = fvalidate(token, footer);
+    var _utils$parse = utils.parse('utf-8')(footer);
+
+    var _utils$parse2 = _slicedToArray(_utils$parse, 1);
+
+    footer = _utils$parse2[0];
+
+    token = fvalidate(token, footer);
   }
 
-  let payload = hvalidate(token, header);
-  [ payload ] = (utils.parse('base64'))(payload);
+  var payload = hvalidate(token, header);
 
-  return [ header, payload, footer ];
+  var _utils$parse3 = utils.parse('base64')(payload);
+
+  var _utils$parse4 = _slicedToArray(_utils$parse3, 1);
+
+  payload = _utils$parse4[0];
+
+
+  return [header, payload, footer];
 }

--- a/lib/key/private.js
+++ b/lib/key/private.js
@@ -1,15 +1,15 @@
-const sodium = require('libsodium-wrappers-sumo');
+'use strict';
 
-const extcrypto = require('../../extcrypto');
-const V1        = require('../protocol/V1');
-const V2        = require('../protocol/V2');
-const utils     = require('../utils');
-const PublicKey = require('./public');
+var sodium = require('libsodium-wrappers-sumo');
 
+var extcrypto = require('../../extcrypto');
+var V1 = require('../protocol/V1');
+var V2 = require('../protocol/V2');
+var utils = require('../utils');
+var PublicKey = require('./public');
 
 // patch
 sodium.crypto_sign_KEYPAIRBYTES = sodium.crypto_sign_SECRETKEYBYTES + sodium.crypto_sign_PUBLICKEYBYTES;
-
 
 /***
  * PrivateKey
@@ -24,12 +24,11 @@ sodium.crypto_sign_KEYPAIRBYTES = sodium.crypto_sign_SECRETKEYBYTES + sodium.cry
  */
 module.exports = PrivateKey;
 function PrivateKey(protocol) {
-  const self = this;
+  var self = this;
   protocol = protocol || new V2();
 
   self._protocol = protocol;
 }
-
 
 /***
  * inject
@@ -46,23 +45,25 @@ function PrivateKey(protocol) {
  */
 PrivateKey.prototype.inject = inject;
 function inject(rkey, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
     if (protocol instanceof V2) {
 
-      if (!(rkey instanceof Buffer)) { return done(new TypeError('Raw key must be provided as a buffer')); }
+      if (!(rkey instanceof Buffer)) {
+        return done(new TypeError('Raw key must be provided as a buffer'));
+      }
 
-      const len = Buffer.byteLength(rkey);
+      var len = Buffer.byteLength(rkey);
 
       if (len === sodium.crypto_sign_KEYPAIRBYTES) {
         rkey = rkey.slice(0, sodium.crypto_sign_SECRETKEYBYTES);
       } else if (len !== sodium.crypto_sign_SECRETKEYBYTES) {
 
         if (len !== sodium.crypto_sign_SEEDBYTES) {
-          throw new Error('Secret keys must be 32 or 64 bytes long; ' + len + ' given.')
+          throw new Error('Secret keys must be 32 or 64 bytes long; ' + len + ' given.');
         }
 
         rkey = Buffer.from(sodium.crypto_sign_seed_keypair(rkey).privateKey);
@@ -74,7 +75,6 @@ function inject(rkey, cb) {
     return done();
   });
 }
-
 
 /***
  * base64
@@ -94,7 +94,6 @@ function base64(skey, cb) {
   return this.inject(utils.fromB64URLSafe(skey), cb);
 }
 
-
 /***
  * hex
  *
@@ -113,7 +112,6 @@ function hex(skey, cb) {
   return this.inject(Buffer.from(skey, 'hex'), cb);
 }
 
-
 /***
  * generate
  *
@@ -127,17 +125,18 @@ function hex(skey, cb) {
  */
 PrivateKey.prototype.generate = generate;
 function generate(cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
-    return (self.protocol() instanceof V1)
-      ? self.inject(extcrypto.keygen(), (err) => { return done(err); })
-      : self.inject(Buffer.from(sodium.crypto_sign_keypair().privateKey), (err) => { return done(err); });
+    return self.protocol() instanceof V1 ? self.inject(extcrypto.keygen(), function (err) {
+      return done(err);
+    }) : self.inject(Buffer.from(sodium.crypto_sign_keypair().privateKey), function (err) {
+      return done(err);
+    });
   });
 }
-
 
 /***
  * V1
@@ -154,7 +153,6 @@ function v1() {
   return new PrivateKey(new V1());
 }
 
-
 /***
  * V2
  *
@@ -170,7 +168,6 @@ function v2() {
   return new PrivateKey(new V2());
 }
 
-
 /***
  * public
  *
@@ -184,22 +181,21 @@ function v2() {
  */
 PrivateKey.prototype.public = _public;
 function _public(cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
-  const pk = new PublicKey(self.protocol());
+  var pk = new PublicKey(self.protocol());
 
   // we don't have to check sodium first because we wouldn't have this private key without it
-  const rkey = (self.protocol instanceof V1)
-        ? extcrypto.extract(self.raw())
-        : Buffer.from(sodium.crypto_sign_ed25519_sk_to_pk(self.raw()));
+  var rkey = self.protocol instanceof V1 ? extcrypto.extract(self.raw()) : Buffer.from(sodium.crypto_sign_ed25519_sk_to_pk(self.raw()));
 
-  return pk.inject(rkey, (err) => {
-    if (err) { return done(err); }
+  return pk.inject(rkey, function (err) {
+    if (err) {
+      return done(err);
+    }
     return done(null, pk);
   });
 }
-
 
 /***
  * protocol
@@ -216,7 +212,6 @@ function protocol() {
   return this._protocol;
 }
 
-
 /***
  * encode
  *
@@ -231,7 +226,6 @@ PrivateKey.prototype.encode = encode;
 function encode() {
   return utils.toB64URLSafe(this._key);
 }
-
 
 /***
  * raw
@@ -248,13 +242,9 @@ function raw() {
   return this._key;
 }
 
-
-
 /**************
  * Subclasses *
  **************/
-
-
 
 /***
  * PrivateKeyV1
@@ -270,7 +260,6 @@ function PrivateKeyV1() {
 }
 PrivateKeyV1.prototype = Object.create(PrivateKey.prototype);
 PrivateKeyV1.prototype.constructor = PrivateKeyV1;
-
 
 /***
  * PrivateKeyV2

--- a/lib/key/public.js
+++ b/lib/key/public.js
@@ -1,9 +1,10 @@
-const sodium = require('libsodium-wrappers-sumo');
+'use strict';
 
-const V1    = require('../protocol/V1');
-const V2    = require('../protocol/V2');
-const utils = require('../utils');
+var sodium = require('libsodium-wrappers-sumo');
 
+var V1 = require('../protocol/V1');
+var V2 = require('../protocol/V2');
+var utils = require('../utils');
 
 /***
  * PublicKey
@@ -18,12 +19,11 @@ const utils = require('../utils');
  */
 module.exports = PublicKey;
 function PublicKey(protocol) {
-  const self = this;
+  var self = this;
   protocol = protocol || new V2();
 
   self._protocol = protocol;
 }
-
 
 /***
  * inject
@@ -40,16 +40,18 @@ function PublicKey(protocol) {
  */
 PublicKey.prototype.inject = inject;
 function inject(rkey, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
     if (protocol instanceof V2) {
 
-      if (!(rkey instanceof Buffer)) { return done(new TypeError('Raw key must be provided as a buffer')); }
+      if (!(rkey instanceof Buffer)) {
+        return done(new TypeError('Raw key must be provided as a buffer'));
+      }
 
-      const len = Buffer.byteLength(rkey);
+      var len = Buffer.byteLength(rkey);
 
       if (len !== sodium.crypto_sign_PUBLICKEYBYTES) {
         return done(new Error('Public keys must be 32 bytes long; ' + len + ' given.'));
@@ -61,7 +63,6 @@ function inject(rkey, cb) {
     return done();
   });
 }
-
 
 /***
  * base64
@@ -81,7 +82,6 @@ function base64(skey, cb) {
   return this.inject(utils.fromB64URLSafe(skey), cb);
 }
 
-
 /***
  * hex
  *
@@ -100,7 +100,6 @@ function hex(skey, cb) {
   return this.inject(Buffer.from(skey, 'hex'), cb);
 }
 
-
 /***
  * V1
  *
@@ -115,7 +114,6 @@ PublicKey.V1 = v1;
 function v1() {
   return new PublicKey(new V1());
 }
-
 
 /***
  * V2
@@ -132,7 +130,6 @@ function v2() {
   return new PublicKey(new V2());
 }
 
-
 /***
  * protocol
  *
@@ -147,7 +144,6 @@ PublicKey.prototype.protocol = protocol;
 function protocol() {
   return this._protocol;
 }
-
 
 /***
  * encode
@@ -164,7 +160,6 @@ function encode() {
   return utils.toB64URLSafe(this._key);
 }
 
-
 /***
  * raw
  *
@@ -180,13 +175,9 @@ function raw() {
   return this._key;
 }
 
-
-
 /**************
  * Subclasses *
  **************/
-
-
 
 /***
  * PublicKeyV1
@@ -202,7 +193,6 @@ function PublicKeyV1() {
 }
 PublicKeyV1.prototype = Object.create(PublicKey.prototype);
 PublicKeyV1.prototype.constructor = PublicKeyV1;
-
 
 /***
  * PublicKeyV2

--- a/lib/key/symmetric.js
+++ b/lib/key/symmetric.js
@@ -1,10 +1,11 @@
-const sodium = require('libsodium-wrappers-sumo');
-const crypto = require('crypto');
+'use strict';
 
-const V1    = require('../protocol/V1');
-const V2    = require('../protocol/V2');
-const utils = require('../utils');
+var sodium = require('libsodium-wrappers-sumo');
+var crypto = require('crypto');
 
+var V1 = require('../protocol/V1');
+var V2 = require('../protocol/V2');
+var utils = require('../utils');
 
 /***
  * SymmetricKey
@@ -19,14 +20,13 @@ const utils = require('../utils');
  */
 module.exports = SymmetricKey;
 function SymmetricKey(protocol) {
-  const self = this;
+  var self = this;
 
-  self.INFO_ENCRYPTION     = 'paseto-encryption-key';
+  self.INFO_ENCRYPTION = 'paseto-encryption-key';
   self.INFO_AUTHENTICATION = 'paseto-auth-key-for-aead';
 
   self._protocol = protocol || new V2();
 }
-
 
 /***
  * inject
@@ -43,17 +43,18 @@ function SymmetricKey(protocol) {
  */
 SymmetricKey.prototype.inject = inject;
 function inject(rkey, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
-  if (!(rkey instanceof Buffer)) { return done(new TypeError('Raw key must be provided as a buffer')); }
+  if (!(rkey instanceof Buffer)) {
+    return done(new TypeError('Raw key must be provided as a buffer'));
+  }
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
     self._key = rkey;
     return done();
   });
 }
-
 
 /***
  * base64
@@ -73,7 +74,6 @@ function base64(skey, cb) {
   return this.inject(utils.fromB64URLSafe(skey), cb);
 }
 
-
 /***
  * hex
  *
@@ -92,7 +92,6 @@ function hex(skey, cb) {
   return this.inject(Buffer.from(skey, 'hex'), cb);
 }
 
-
 /***
  * generate
  *
@@ -106,14 +105,15 @@ function hex(skey, cb) {
  */
 SymmetricKey.prototype.generate = generate;
 function generate(cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
-  return sodium.ready.then(() => {
-    return self.inject(crypto.randomBytes(self.protocol().sklength()), (err) => { return done(err); });
+  return sodium.ready.then(function () {
+    return self.inject(crypto.randomBytes(self.protocol().sklength()), function (err) {
+      return done(err);
+    });
   });
 }
-
 
 /***
  * V1
@@ -130,7 +130,6 @@ function v1() {
   return new SymmetricKey(new V1());
 }
 
-
 /***
  * V2
  *
@@ -145,7 +144,6 @@ SymmetricKey.V2 = v2;
 function v2() {
   return new SymmetricKey(new V2());
 }
-
 
 /***
  * protocol
@@ -162,7 +160,6 @@ function protocol() {
   return this._protocol;
 }
 
-
 /***
  * encode
  *
@@ -177,7 +174,6 @@ SymmetricKey.prototype.encode = encode;
 function encode() {
   return utils.toB64URLSafe(this._key);
 }
-
 
 /***
  * raw
@@ -194,7 +190,6 @@ function raw() {
   return this._key;
 }
 
-
 /***
  * split
  *
@@ -209,26 +204,26 @@ function raw() {
  */
 SymmetricKey.prototype.split = split;
 function split(salt, done) {
-  const self = this;
-  const hkdf = utils.hkdf('sha384');
+  var self = this;
+  var hkdf = utils.hkdf('sha384');
 
-  hkdf(self._key, salt, 32, self.INFO_ENCRYPTION, (err, ekey) => {
-    if (err) { return done(err); }
+  hkdf(self._key, salt, 32, self.INFO_ENCRYPTION, function (err, ekey) {
+    if (err) {
+      return done(err);
+    }
 
-    hkdf(self._key, salt, 32, self.INFO_AUTHENTICATION, (err, akey) => {
-      if (err) { return done(err); }
-      return done(null, [ ekey, akey ]);
+    hkdf(self._key, salt, 32, self.INFO_AUTHENTICATION, function (err, akey) {
+      if (err) {
+        return done(err);
+      }
+      return done(null, [ekey, akey]);
     });
   });
 }
 
-
-
 /**************
  * Subclasses *
  **************/
-
-
 
 /***
  * SymmetricKeyV1
@@ -244,7 +239,6 @@ function SymmetricKeyV1() {
 }
 SymmetricKeyV1.prototype = Object.create(SymmetricKey.prototype);
 SymmetricKeyV1.prototype.constructor = SymmetricKeyV1;
-
 
 /***
  * SymmetricKeyV2

--- a/lib/protocol/V1.js
+++ b/lib/protocol/V1.js
@@ -1,13 +1,16 @@
-const crypto = require('crypto');
+'use strict';
 
-const extcrypto   = require('../../extcrypto');
-const utils       = require('../utils');
-const decapsulate = require('../decapsulate');
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-const PasetoError         = require('../error/PasetoError');
-const SecurityError       = require('../error/SecurityError');
-const InvalidVersionError = require('../error/InvalidVersionError');
+var crypto = require('crypto');
 
+var extcrypto = require('../../extcrypto');
+var utils = require('../utils');
+var decapsulate = require('../decapsulate');
+
+var PasetoError = require('../error/PasetoError');
+var SecurityError = require('../error/SecurityError');
+var InvalidVersionError = require('../error/InvalidVersionError');
 
 /***
  * V1
@@ -25,13 +28,12 @@ function V1() {
     SYMMETRIC_KEY_BYTES: 32,
 
     CIPHER_MODE: 'aes-256-ctr',
-    HASH_ALGO:   'sha384',
-    NONCE_SIZE:  32,
-    MAC_SIZE:    48,
-    SIGN_SIZE:   256
-  }
+    HASH_ALGO: 'sha384',
+    NONCE_SIZE: 32,
+    MAC_SIZE: 48,
+    SIGN_SIZE: 256
+  };
 }
-
 
 /***
  * private
@@ -46,17 +48,18 @@ function V1() {
  */
 V1.prototype.private = pk;
 function pk(cb) {
-  const done = utils.ret(cb);
+  var done = utils.ret(cb);
 
   // minor hack to mimic php api without circular dependency - probably a better way to do this
-  const PrivateKey = require('../key/private');
-  const pk = new PrivateKey(new V1());
-  return pk.generate((err) => {
-    if (err) { return done(err); }
+  var PrivateKey = require('../key/private');
+  var pk = new PrivateKey(new V1());
+  return pk.generate(function (err) {
+    if (err) {
+      return done(err);
+    }
     return done(null, pk);
   });
 }
-
 
 /***
  * symmetric
@@ -71,17 +74,18 @@ function pk(cb) {
  */
 V1.prototype.symmetric = sk;
 function sk(cb) {
-  const done = utils.ret(cb);
+  var done = utils.ret(cb);
 
   // minor hack to mimic php api without circular dependency - probably a better way to do this
-  const SymmetricKey = require('../key/symmetric');
-  const sk = new SymmetricKey(new V1());
-  return sk.generate((err) => {
-    if (err) { return done(err); }
+  var SymmetricKey = require('../key/symmetric');
+  var sk = new SymmetricKey(new V1());
+  return sk.generate(function (err) {
+    if (err) {
+      return done(err);
+    }
     return done(null, sk);
   });
 }
-
 
 /***
  * repr
@@ -98,7 +102,6 @@ function repr() {
   return this._repr;
 }
 
-
 /***
  * sklength
  *
@@ -113,7 +116,6 @@ V1.prototype.sklength = sklength;
 function sklength() {
   return this._constants.SYMMETRIC_KEY_BYTES;
 }
-
 
 /***
  * __encrypt
@@ -134,21 +136,30 @@ V1.prototype.__encrypt = __encrypt;
 function __encrypt(data, key, footer, nonce, cb) {
   footer = footer || '';
 
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V1)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  const header = utils.local(self);
+  var header = utils.local(self);
 
-  [ data, footer, nonce ] = (utils.parse('utf-8'))(data, footer, nonce);
+  var _utils$parse = utils.parse('utf-8')(data, footer, nonce);
 
-  return self.aeadEncrypt(key, header, data, footer, nonce)
-    .then((token) => { return done(null, token); }).catch((err) => { return done(err); });
+  var _utils$parse2 = _slicedToArray(_utils$parse, 3);
+
+  data = _utils$parse2[0];
+  footer = _utils$parse2[1];
+  nonce = _utils$parse2[2];
+
+
+  return self.aeadEncrypt(key, header, data, footer, nonce).then(function (token) {
+    return done(null, token);
+  }).catch(function (err) {
+    return done(err);
+  });
 }
-
 
 /***
  * encrypt
@@ -169,7 +180,6 @@ function encrypt(data, key, footer, cb) {
   return this.__encrypt(data, key, footer, '', cb);
 }
 
-
 /***
  * decrypt
  *
@@ -186,24 +196,33 @@ function encrypt(data, key, footer, cb) {
  */
 V1.prototype.decrypt = decrypt;
 function decrypt(token, key, footer, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V1)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  let payload, header = utils.local(self);
+  var payload = void 0,
+      header = utils.local(self);
   try {
-    [ header, payload, footer ] = decapsulate(header, token, footer);
+    var _decapsulate = decapsulate(header, token, footer);
+
+    var _decapsulate2 = _slicedToArray(_decapsulate, 3);
+
+    header = _decapsulate2[0];
+    payload = _decapsulate2[1];
+    footer = _decapsulate2[2];
   } catch (ex) {
     return done(ex);
   }
 
-  return self.aeadDecrypt(key, header, payload, footer)
-    .then((data) => { return done(null, data); }).catch((err) => { return done(err); });
+  return self.aeadDecrypt(key, header, payload, footer).then(function (data) {
+    return done(null, data);
+  }).catch(function (err) {
+    return done(err);
+  });
 }
-
 
 /***
  * sign
@@ -223,35 +242,36 @@ V1.prototype.sign = sign;
 function sign(data, key, footer, cb) {
   footer = footer || '';
 
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V1)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  const header = utils.public(self);
-
-  [ data, footer ] = (utils.parse('utf-8'))(data, footer);
+  var header = utils.public(self);
 
   // sign
 
-  const payload = utils.pae(header, data, footer);
-  const signer  = crypto.createSign('SHA384');
+  var _utils$parse3 = utils.parse('utf-8')(data, footer);
+
+  var _utils$parse4 = _slicedToArray(_utils$parse3, 2);
+
+  data = _utils$parse4[0];
+  footer = _utils$parse4[1];
+  var payload = utils.pae(header, data, footer);
+  var signer = crypto.createSign('SHA384');
   signer.update(payload);
   signer.end();
 
-  const signature = signer.sign({ key: key.raw(), padding: crypto.constants.RSA_PKCS1_PSS_PADDING });
+  var signature = signer.sign({ key: key.raw(), padding: crypto.constants.RSA_PKCS1_PSS_PADDING });
 
   // format
 
-  const token = header.toString('utf-8') + utils.toB64URLSafe(Buffer.concat([ data, signature ]));
+  var token = header.toString('utf-8') + utils.toB64URLSafe(Buffer.concat([data, signature]));
 
-  return (!Buffer.byteLength(footer))
-    ? done(null, token)
-    : done(null, token + '.' + utils.toB64URLSafe(footer));
+  return !Buffer.byteLength(footer) ? done(null, token) : done(null, token + '.' + utils.toB64URLSafe(footer));
 }
-
 
 /***
  * verify
@@ -269,43 +289,51 @@ function sign(data, key, footer, cb) {
  */
 V1.prototype.verify = verify;
 function verify(token, key, footer, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V1)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  let payload, header = utils.public(self);
+  var payload = void 0,
+      header = utils.public(self);
   try {
-    [ header, payload, footer ] = decapsulate(header, token, footer);
+    var _decapsulate3 = decapsulate(header, token, footer);
+
+    var _decapsulate4 = _slicedToArray(_decapsulate3, 3);
+
+    header = _decapsulate4[0];
+    payload = _decapsulate4[1];
+    footer = _decapsulate4[2];
   } catch (ex) {
     return done(ex);
   }
 
   // recover data
 
-  const plen = Buffer.byteLength(payload);
+  var plen = Buffer.byteLength(payload);
 
-  const data      = Buffer.from(payload).slice(0, plen - self._constants.SIGN_SIZE);
-  const signature = Buffer.from(payload).slice(plen - self._constants.SIGN_SIZE);
+  var data = Buffer.from(payload).slice(0, plen - self._constants.SIGN_SIZE);
+  var signature = Buffer.from(payload).slice(plen - self._constants.SIGN_SIZE);
 
   // verify signature
 
-  const expected = utils.pae(header, data, footer);
-  const verifier = crypto.createVerify('SHA384');
+  var expected = utils.pae(header, data, footer);
+  var verifier = crypto.createVerify('SHA384');
   verifier.update(expected);
   verifier.end();
 
-  const valid = verifier.verify({ key: key.raw(), padding: crypto.constants.RSA_PKCS1_PSS_PADDING }, signature);
+  var valid = verifier.verify({ key: key.raw(), padding: crypto.constants.RSA_PKCS1_PSS_PADDING }, signature);
 
-  if (!valid) { return done(new PasetoError('Invalid signature for this message')); }
+  if (!valid) {
+    return done(new PasetoError('Invalid signature for this message'));
+  }
 
   // format
 
   return done(null, data.toString('utf-8'));
 }
-
 
 /***
  * public
@@ -323,7 +351,6 @@ function gpublic(sk) {
   return extcrypto.extract(sk);
 }
 
-
 /***
  * nonce
  *
@@ -338,10 +365,9 @@ function gpublic(sk) {
  */
 V1.prototype.nonce = nonce;
 function nonce(mess, nkey) {
-  const self = this;
+  var self = this;
   return crypto.createHmac(self._constants.HASH_ALGO, nkey).update(mess).digest().slice(0, 32);
 }
-
 
 /***
  * aeadEncrypt
@@ -360,37 +386,39 @@ function nonce(mess, nkey) {
  */
 V1.prototype.aeadEncrypt = aeadEncrypt;
 function aeadEncrypt(key, header, plaintext, footer, nonce) {
-  const self = this;
+  var self = this;
 
-  return new Promise((resolve, reject) => {
-    nonce = (!!nonce)
-      ? self.nonce(plaintext, nonce)
-      : self.nonce(plaintext, crypto.randomBytes(self._constants.NONCE_SIZE));
+  return new Promise(function (resolve, reject) {
+    nonce = !!nonce ? self.nonce(plaintext, nonce) : self.nonce(plaintext, crypto.randomBytes(self._constants.NONCE_SIZE));
 
-    key.split(nonce.slice(0, 16), (err, keys) => {
-      if (err) { return reject(err); }
-      const [ enckey, authkey ] = keys;
+    key.split(nonce.slice(0, 16), function (err, keys) {
+      if (err) {
+        return reject(err);
+      }
 
-      const encryptor  = crypto.createCipheriv(self._constants.CIPHER_MODE, enckey, nonce.slice(16, 32));
-      const ciphertext = Buffer.concat([ encryptor.update(plaintext), encryptor.final() ]);
+      var _keys = _slicedToArray(keys, 2),
+          enckey = _keys[0],
+          authkey = _keys[1];
+
+      var encryptor = crypto.createCipheriv(self._constants.CIPHER_MODE, enckey, nonce.slice(16, 32));
+      var ciphertext = Buffer.concat([encryptor.update(plaintext), encryptor.final()]);
 
       // an empty buffer is truthy, if no plaintext
-      if (!ciphertext) { return reject(new PasetoError('Encryption failed.')); }
+      if (!ciphertext) {
+        return reject(new PasetoError('Encryption failed.'));
+      }
 
-      const payload = utils.pae(header, nonce, ciphertext, footer);
+      var payload = utils.pae(header, nonce, ciphertext, footer);
 
-      const authenticator = crypto.createHmac(self._constants.HASH_ALGO, authkey);
-      const mac           = authenticator.update(payload).digest();
+      var authenticator = crypto.createHmac(self._constants.HASH_ALGO, authkey);
+      var mac = authenticator.update(payload).digest();
 
-      const token = header.toString('utf-8') + utils.toB64URLSafe(Buffer.concat([ nonce, ciphertext, mac ]));
+      var token = header.toString('utf-8') + utils.toB64URLSafe(Buffer.concat([nonce, ciphertext, mac]));
 
-      return (!Buffer.byteLength(footer))
-        ? resolve(token)
-        : resolve(token + '.' + utils.toB64URLSafe(footer));
+      return !Buffer.byteLength(footer) ? resolve(token) : resolve(token + '.' + utils.toB64URLSafe(footer));
     });
   });
 }
-
 
 /***
  * aeadDecrypt
@@ -408,39 +436,48 @@ function aeadEncrypt(key, header, plaintext, footer, nonce) {
  */
 V1.prototype.aeadDecrypt = aeadDecrypt;
 function aeadDecrypt(key, header, payload, footer) {
-  const self = this;
+  var self = this;
 
-  return new Promise((resolve, reject) => {
+  return new Promise(function (resolve, reject) {
 
     // recover nonce
 
-    const plen = Buffer.byteLength(payload);
+    var plen = Buffer.byteLength(payload);
 
-    const nlen  = self._constants.NONCE_SIZE;
-    const nonce = Buffer.from(payload).slice(0, nlen);
+    var nlen = self._constants.NONCE_SIZE;
+    var nonce = Buffer.from(payload).slice(0, nlen);
 
     // decrypt and verify
 
-    const ciphertext = Buffer.from(payload).slice(nlen, plen - self._constants.MAC_SIZE);
-    const mac        = Buffer.from(payload).slice(plen - self._constants.MAC_SIZE);
+    var ciphertext = Buffer.from(payload).slice(nlen, plen - self._constants.MAC_SIZE);
+    var mac = Buffer.from(payload).slice(plen - self._constants.MAC_SIZE);
 
-    key.split(nonce.slice(0, 16), (err, keys) => {
-      if (err) { return reject(err); }
-      const [ enckey, authkey ] = keys;
+    key.split(nonce.slice(0, 16), function (err, keys) {
+      if (err) {
+        return reject(err);
+      }
 
-      const payload = utils.pae(header, nonce, ciphertext, footer);
+      var _keys2 = _slicedToArray(keys, 2),
+          enckey = _keys2[0],
+          authkey = _keys2[1];
 
-      const authenticator = crypto.createHmac(self._constants.HASH_ALGO, authkey);
-      const calc          = authenticator.update(payload).digest();
+      var payload = utils.pae(header, nonce, ciphertext, footer);
 
-      if (!utils.cnstcomp(mac, calc)) { return reject(new SecurityError('Invalid MAC for given ciphertext.')); }
+      var authenticator = crypto.createHmac(self._constants.HASH_ALGO, authkey);
+      var calc = authenticator.update(payload).digest();
 
-      const decryptor  = crypto.createDecipheriv(self._constants.CIPHER_MODE, enckey, nonce.slice(16, 32));
-      const _plaintext = Buffer.concat([ decryptor.update(ciphertext), decryptor.final() ]);
-      const plaintext  = Buffer.from(_plaintext);
+      if (!utils.cnstcomp(mac, calc)) {
+        return reject(new SecurityError('Invalid MAC for given ciphertext.'));
+      }
+
+      var decryptor = crypto.createDecipheriv(self._constants.CIPHER_MODE, enckey, nonce.slice(16, 32));
+      var _plaintext = Buffer.concat([decryptor.update(ciphertext), decryptor.final()]);
+      var plaintext = Buffer.from(_plaintext);
 
       // an empty buffer is truthy, if no ciphertext
-      if (!plaintext) { return reject(new PasetoError('Decryption failed.')); }
+      if (!plaintext) {
+        return reject(new PasetoError('Decryption failed.'));
+      }
 
       // format
 

--- a/lib/protocol/V2.js
+++ b/lib/protocol/V2.js
@@ -1,11 +1,14 @@
-const sodium = require('libsodium-wrappers-sumo');
+'use strict';
 
-const utils       = require('../utils')
-const decapsulate = require('../decapsulate');
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-const PasetoError         = require('../error/PasetoError');
-const InvalidVersionError = require('../error/InvalidVersionError');
+var sodium = require('libsodium-wrappers-sumo');
 
+var utils = require('../utils');
+var decapsulate = require('../decapsulate');
+
+var PasetoError = require('../error/PasetoError');
+var InvalidVersionError = require('../error/InvalidVersionError');
 
 /***
  * V2
@@ -21,9 +24,8 @@ function V2() {
 
   this._constants = {
     SYMMETRIC_KEY_BYTES: 32
-  }
+  };
 }
-
 
 /***
  * private
@@ -38,17 +40,18 @@ function V2() {
  */
 V2.prototype.private = pk;
 function pk(cb) {
-  const done = utils.ret(cb);
+  var done = utils.ret(cb);
 
   // minor hack to mimic php api without circular dependency - probably a better way to do this
-  const PrivateKey = require('../key/private');
-  const pk = new PrivateKey(new V2());
-  return pk.generate((err) => {
-    if (err) { return done(err); }
+  var PrivateKey = require('../key/private');
+  var pk = new PrivateKey(new V2());
+  return pk.generate(function (err) {
+    if (err) {
+      return done(err);
+    }
     return done(null, pk);
   });
 }
-
 
 /***
  * symmetric
@@ -63,17 +66,18 @@ function pk(cb) {
  */
 V2.prototype.symmetric = sk;
 function sk(cb) {
-  const done = utils.ret(cb);
+  var done = utils.ret(cb);
 
   // minor hack to mimic php api without circular dependency - probably a better way to do this
-  const SymmetricKey = require('../key/symmetric');
-  const sk = new SymmetricKey(new V2());
-  return sk.generate((err) => {
-    if (err) { return done(err); }
+  var SymmetricKey = require('../key/symmetric');
+  var sk = new SymmetricKey(new V2());
+  return sk.generate(function (err) {
+    if (err) {
+      return done(err);
+    }
     return done(null, sk);
   });
 }
-
 
 /***
  * repr
@@ -90,7 +94,6 @@ function repr() {
   return this._repr;
 }
 
-
 /***
  * sklength
  *
@@ -105,7 +108,6 @@ V2.prototype.sklength = sklength;
 function sklength() {
   return this._constants.SYMMETRIC_KEY_BYTES;
 }
-
 
 /***
  * __encrypt
@@ -126,20 +128,27 @@ V2.prototype.__encrypt = __encrypt;
 function __encrypt(data, key, footer, nonce, cb) {
   footer = footer || '';
 
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V2)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
-    const header = utils.local(self);
+    var header = utils.local(self);
 
-    [ data, footer, nonce ] = (utils.parse('utf-8'))(data, footer, nonce);
+    var _utils$parse = utils.parse('utf-8')(data, footer, nonce);
 
-    let token;
+    var _utils$parse2 = _slicedToArray(_utils$parse, 3);
+
+    data = _utils$parse2[0];
+    footer = _utils$parse2[1];
+    nonce = _utils$parse2[2];
+
+
+    var token = void 0;
     try {
       token = aeadEncrypt(key, header, data, footer, nonce);
     } catch (ex) {
@@ -149,7 +158,6 @@ function __encrypt(data, key, footer, nonce, cb) {
     return done(null, token);
   });
 }
-
 
 /***
  * encrypt
@@ -170,7 +178,6 @@ function encrypt(data, key, footer, cb) {
   return this.__encrypt(data, key, footer, '', cb);
 }
 
-
 /***
  * decrypt
  *
@@ -185,20 +192,29 @@ function encrypt(data, key, footer, cb) {
  * @param {Function} cb
  * @returns {Callback|Promise}
  */
-V2.prototype.decrypt = decrypt
+V2.prototype.decrypt = decrypt;
 function decrypt(token, key, footer, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V2)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
-    let payload, data, header = utils.local(self);
+    var payload = void 0,
+        data = void 0,
+        header = utils.local(self);
     try {
-      [ header, payload, footer ] = decapsulate(header, token, footer);
+      var _decapsulate = decapsulate(header, token, footer);
+
+      var _decapsulate2 = _slicedToArray(_decapsulate, 3);
+
+      header = _decapsulate2[0];
+      payload = _decapsulate2[1];
+      footer = _decapsulate2[2];
+
 
       data = aeadDecrypt(key, header, payload, footer);
     } catch (ex) {
@@ -208,7 +224,6 @@ function decrypt(token, key, footer, cb) {
     return done(null, data);
   });
 }
-
 
 /***
  * sign
@@ -228,35 +243,36 @@ V2.prototype.sign = sign;
 function sign(data, key, footer, cb) {
   footer = footer || '';
 
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V2)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
-    const header = utils.public(self);
-
-    [ data, footer ] = (utils.parse('utf-8'))(data, footer);
+    var header = utils.public(self);
 
     // sign
 
-    const payload    = utils.pae(header, data, footer);
-    const _signature = sodium.crypto_sign_detached(payload, key.raw());
-    const signature  = Buffer.from(_signature);
+    var _utils$parse3 = utils.parse('utf-8')(data, footer);
+
+    var _utils$parse4 = _slicedToArray(_utils$parse3, 2);
+
+    data = _utils$parse4[0];
+    footer = _utils$parse4[1];
+    var payload = utils.pae(header, data, footer);
+    var _signature = sodium.crypto_sign_detached(payload, key.raw());
+    var signature = Buffer.from(_signature);
 
     // format
 
-    const token = header.toString('utf-8') + utils.toB64URLSafe(Buffer.concat([ data, signature ]));
+    var token = header.toString('utf-8') + utils.toB64URLSafe(Buffer.concat([data, signature]));
 
-    return (!Buffer.byteLength(footer))
-      ? done(null, token)
-      : done(null, token + '.' + utils.toB64URLSafe(footer));
+    return !Buffer.byteLength(footer) ? done(null, token) : done(null, token + '.' + utils.toB64URLSafe(footer));
   });
 }
-
 
 /***
  * verify
@@ -274,42 +290,50 @@ function sign(data, key, footer, cb) {
  */
 V2.prototype.verify = verify;
 function verify(token, key, footer, cb) {
-  const self = this;
-  const done = utils.ret(cb);
+  var self = this;
+  var done = utils.ret(cb);
 
   if (!(key.protocol() instanceof V2)) {
     return done(new InvalidVersionError('The given key is not intended for this version of PASETO.'));
   }
 
-  return sodium.ready.then(() => {
+  return sodium.ready.then(function () {
 
-    let payload, header = utils.public(self);
+    var payload = void 0,
+        header = utils.public(self);
     try {
-      [ header, payload, footer ] = decapsulate(header, token, footer);
+      var _decapsulate3 = decapsulate(header, token, footer);
+
+      var _decapsulate4 = _slicedToArray(_decapsulate3, 3);
+
+      header = _decapsulate4[0];
+      payload = _decapsulate4[1];
+      footer = _decapsulate4[2];
     } catch (ex) {
       return done(ex);
     }
 
     // recover data
 
-    const plen = Buffer.byteLength(payload);
+    var plen = Buffer.byteLength(payload);
 
-    const data      = Buffer.from(payload).slice(0, plen - sodium.crypto_sign_BYTES);
-    const signature = Buffer.from(payload).slice(plen - sodium.crypto_sign_BYTES);
+    var data = Buffer.from(payload).slice(0, plen - sodium.crypto_sign_BYTES);
+    var signature = Buffer.from(payload).slice(plen - sodium.crypto_sign_BYTES);
 
     // verify signature
 
-    const expected = utils.pae(header, data, footer);
-    const valid    = sodium.crypto_sign_verify_detached(signature, expected, key.raw());
+    var expected = utils.pae(header, data, footer);
+    var valid = sodium.crypto_sign_verify_detached(signature, expected, key.raw());
 
-    if (!valid) { return done(new PasetoError('Invalid signature for this message')); }
+    if (!valid) {
+      return done(new PasetoError('Invalid signature for this message'));
+    }
 
     // format
 
     return done(null, data.toString('utf-8'));
   });
 }
-
 
 /***
  * aeadEncrypt
@@ -331,28 +355,25 @@ function aeadEncrypt(key, header, plaintext, footer, nonce) {
 
   // build nonce
 
-  const nlen   = sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
-  const nkey   = nonce || sodium.randombytes_buf(nlen);
-  const _nonce = sodium.crypto_generichash(nlen, plaintext, nkey);
+  var nlen = sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+  var nkey = nonce || sodium.randombytes_buf(nlen);
+  var _nonce = sodium.crypto_generichash(nlen, plaintext, nkey);
 
   nonce = Buffer.from(_nonce);
 
   // encrypt
 
-  const ad          = utils.pae(header, nonce, footer);
-  const _ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(plaintext, ad, null, nonce, key.raw());
-  const ciphertext  = Buffer.from(_ciphertext);
+  var ad = utils.pae(header, nonce, footer);
+  var _ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(plaintext, ad, null, nonce, key.raw());
+  var ciphertext = Buffer.from(_ciphertext);
 
   // format
 
-  const payload = Buffer.concat([ nonce, ciphertext ]);
-  const token   = header.toString('utf-8') + utils.toB64URLSafe(payload);
+  var payload = Buffer.concat([nonce, ciphertext]);
+  var token = header.toString('utf-8') + utils.toB64URLSafe(payload);
 
-  return (!Buffer.byteLength(footer))
-    ? token
-    : token + '.' + utils.toB64URLSafe(footer);
+  return !Buffer.byteLength(footer) ? token : token + '.' + utils.toB64URLSafe(footer);
 }
-
 
 /***
  * aeadDecrypt
@@ -373,18 +394,18 @@ function aeadDecrypt(key, header, payload, footer) {
 
   // recover nonce
 
-  const plen = Buffer.byteLength(payload);
+  var plen = Buffer.byteLength(payload);
 
-  const nlen  = sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
-  const nonce = Buffer.from(payload).slice(0, nlen);
+  var nlen = sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+  var nonce = Buffer.from(payload).slice(0, nlen);
 
   // decrypt and verify
 
-  const ad         = utils.pae(header, nonce, footer);
-  const ciphertext = Buffer.from(payload).slice(nlen, plen);
+  var ad = utils.pae(header, nonce, footer);
+  var ciphertext = Buffer.from(payload).slice(nlen, plen);
 
-  const _plaintext = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(null, ciphertext, ad, nonce, key.raw());
-  const plaintext  = Buffer.from(_plaintext);
+  var _plaintext = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(null, ciphertext, ad, nonce, key.raw());
+  var plaintext = Buffer.from(_plaintext);
 
   // format
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,9 @@
-const crypto = require('crypto');
-const sodium = require('libsodium-wrappers-sumo');
+'use strict';
 
-const PasetoError = require('./error/PasetoError');
+var crypto = require('crypto');
+var sodium = require('libsodium-wrappers-sumo');
 
+var PasetoError = require('./error/PasetoError');
 
 /***
  * cnstcomp
@@ -18,15 +19,18 @@ const PasetoError = require('./error/PasetoError');
  */
 module.exports.cnstcomp = cnstcomp;
 function cnstcomp(a, b) {
-  if (!(a instanceof Buffer && b instanceof Buffer)) { throw new TypeError('Inputs must be buffers'); }
+  if (!(a instanceof Buffer && b instanceof Buffer)) {
+    throw new TypeError('Inputs must be buffers');
+  }
 
   // use builtin if available
-  if ('timingSafeEqual' in crypto) { return crypto.timingSafeEqual(a, b); }
+  if ('timingSafeEqual' in crypto) {
+    return crypto.timingSafeEqual(a, b);
+  }
 
   // fallback on sodium
   return sodium.compare(a, b) === 0;
 }
-
 
 /***
  * hkdf
@@ -42,7 +46,7 @@ function cnstcomp(a, b) {
 module.exports.hkdf = hkdf;
 function hkdf(alg) {
 
-  let olen;
+  var olen = void 0;
   try {
     olen = crypto.createHmac(alg, '');
   } catch (ex) {
@@ -64,40 +68,42 @@ function hkdf(alg) {
    * @param {Function} done
    * @returns {Buffer}
    */
-  return (key, salt, len, use, done) => {
+  return function (key, salt, len, use, done) {
 
     if (!len || len < 0 || len > 255 * olen) {
       return done(new Error('Bad output length requested of HKDF.'));
     }
 
     // if salt not provided, set it to a string of zeroes.
-    if (!salt) { salt = Buffer.alloc(olen).fill(0); }
+    if (!salt) {
+      salt = Buffer.alloc(olen).fill(0);
+    }
 
-    const prk = crypto.createHmac(alg, salt).update(key).digest();
+    var prk = crypto.createHmac(alg, salt).update(key).digest();
 
     if (Buffer.byteLength(prk) < olen) {
       return done(new Error('An unexpected condition occurred in the HKDF internals'));
     }
 
-    const u = Buffer.from(use);
+    var u = Buffer.from(use);
 
-    let t  = Buffer.from('');
-    let lb = Buffer.from('');
-    let i, ibp;
+    var t = Buffer.from('');
+    var lb = Buffer.from('');
+    var i = void 0;
+    var inp = void 0;
 
-    for (let bi = 1; Buffer.byteLength(t) < len; ++i) {
-      i   = Buffer.from(String.fromCharCode(bi));
-      inp = Buffer.concat([ lb, u, i ]);
+    for (var bi = 1; Buffer.byteLength(t) < len; ++i) {
+      i = Buffer.from(String.fromCharCode(bi));
+      inp = Buffer.concat([lb, u, i]);
 
       lb = crypto.createHmac(alg, prk).update(inp).digest();
-      t  = Buffer.concat([ t, lb ]);
+      t = Buffer.concat([t, lb]);
     }
 
-    const orm = Buffer.from(t).slice(0, len);
+    var orm = Buffer.from(t).slice(0, len);
     return done(null, orm);
-  }
+  };
 }
-
 
 /***
  * parse
@@ -113,8 +119,12 @@ function hkdf(alg) {
 module.exports.parse = parse;
 function parse(as) {
 
-  if ([ 'hex', 'base64', 'utf-8' ].indexOf(as) === -1) { throw new Error('Unknown format'); }
-  const parser = (as === 'base64') ? fromB64URLSafe : (i) => { return Buffer.from(i, as); }
+  if (['hex', 'base64', 'utf-8'].indexOf(as) === -1) {
+    throw new Error('Unknown format');
+  }
+  var parser = as === 'base64' ? fromB64URLSafe : function (i) {
+    return Buffer.from(i, as);
+  };
 
   /***
    * `lambda`
@@ -127,18 +137,19 @@ function parse(as) {
    * @returns {Array}
    */
   return function () {
-    return [ ...arguments ].map((inp) => {
-      if (!inp) { return Buffer.from(''); }
+    return [].concat(Array.prototype.slice.call(arguments)).map(function (inp) {
+      if (!inp) {
+        return Buffer.from('');
+      }
 
       try {
-        return (inp instanceof Buffer) ? inp : parser(inp);
+        return inp instanceof Buffer ? inp : parser(inp);
       } catch (ex) {
         throw new PasetoError('Invalid encoding detected');
       }
     });
-  }
+  };
 }
-
 
 /***
  * pae
@@ -152,21 +163,20 @@ function parse(as) {
  */
 module.exports.pae = pae;
 function pae() {
-  const pieces = (parse('utf-8'))(...arguments);
+  var pieces = parse('utf-8').apply(undefined, arguments);
 
-  let accumulator = Buffer.alloc(8);
+  var accumulator = Buffer.alloc(8);
   accumulator.writeIntLE(pieces.length);
 
-  pieces.forEach((piece) => {
-    let len = Buffer.alloc(8);
+  pieces.forEach(function (piece) {
+    var len = Buffer.alloc(8);
     len.writeIntLE(Buffer.byteLength(piece));
 
-    accumulator = Buffer.concat([ accumulator, len, piece ]);
+    accumulator = Buffer.concat([accumulator, len, piece]);
   });
 
   return accumulator;
 }
-
 
 /***
  * local
@@ -181,10 +191,9 @@ function pae() {
  */
 module.exports.local = local;
 function local(protocol) {
-  const ind = protocol.repr();
+  var ind = protocol.repr();
   return Buffer.from(ind + '.local.', 'utf-8');
 }
-
 
 /***
  * public
@@ -197,12 +206,11 @@ function local(protocol) {
  * @param {Object} protocol
  * @returns {Buffer} header
  */
-module.exports.public = public;
-function public(protocol) {
-  const ind = protocol.repr();
+module.exports.public = publicHeader;
+function publicHeader(protocol) {
+  var ind = protocol.repr();
   return Buffer.from(ind + '.public.', 'utf-8');
 }
-
 
 /***
  * ret
@@ -217,7 +225,7 @@ function public(protocol) {
  */
 module.exports.ret = ret;
 function ret(callback) {
-  const promisify = !(callback && typeof callback === 'function');
+  var promisify = !(callback && typeof callback === 'function');
 
   /***
    * `lambda`
@@ -227,19 +235,24 @@ function ret(callback) {
    * @function
    * @api private
    */
-  return function() {
-    const args = [ ...arguments ];
-    if (!promisify) { return callback.apply(this, args); }
+  return function () {
+    var _this = this;
 
-    return new Promise((resolve, reject) => {
-      const err = args.shift();
-      if (err) { return reject(err); }
+    var args = [].concat(Array.prototype.slice.call(arguments));
+    if (!promisify) {
+      return callback.apply(this, args);
+    }
 
-      return resolve.apply(this, args);
+    return new Promise(function (resolve, reject) {
+      var err = args.shift();
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve.apply(_this, args);
     });
-  }
+  };
 }
-
 
 /***
  * toB64URLSafe
@@ -254,10 +267,11 @@ function ret(callback) {
  */
 module.exports.toB64URLSafe = toB64URLSafe;
 function toB64URLSafe(buf) {
-  if (!(buf instanceof Buffer)) { throw new TypeError('Can only encode buffer'); }
+  if (!(buf instanceof Buffer)) {
+    throw new TypeError('Can only encode buffer');
+  }
   return sodium.to_base64(buf, sodium.base64_variants.URLSAFE_NO_PADDING);
 }
-
 
 /***
  * fromB64URLSafe
@@ -272,6 +286,8 @@ function toB64URLSafe(buf) {
  */
 module.exports.fromB64URLSafe = fromB64URLSafe;
 function fromB64URLSafe(str) {
-  if (!(typeof str === 'string')) { throw new TypeError('Can only decode string'); }
+  if (!(typeof str === 'string')) {
+    throw new TypeError('Can only decode string');
+  }
   return Buffer.from(sodium.from_base64(str, sodium.base64_variants.URLSAFE_NO_PADDING));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,209 @@
+{
+  "name": "paseto.js",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "libsodium-sumo": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.3.tgz",
+      "integrity": "sha512-zCik0rx9XVNKMLY/t+kI6L/+LGomPx/UZ5iiU2YzCDN2K3GPxY2e0OnjJuX/W3/03fRV7W0btNOOgWpvab2P5g=="
+    },
+    "libsodium-wrappers-sumo": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.3.tgz",
+      "integrity": "sha512-JNEZ74zu83BiPxXiYCexVOJdLaNpQTig5bC28MsPzBjzUwIDdLSabEfQNbEtODaNcqq3UlEgYa8IGvDF1jrINA==",
+      "requires": {
+        "libsodium-sumo": "0.7.3"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paseto.js",
-  "version": "0.1.2",
-  "description": "PASETO: Platform-Agnostic Security Tokens",
+  "version": "0.0.0",
+  "description": "PASETO: Platform-Agnostic Security Tokens. Build with Babel to ES5 compatible to enable minifying during create-react-app build. Read more on http://bit.ly/2tRViJ9",
   "main": "lib/paseto.js",
   "author": "Samuel Judson",
   "license": "MIT",


### PR DESCRIPTION
I tried to use the library in browser in React application. create-react-app build failed to minify some javascript files in the library because all scripts are not ES5 compatible (more about this can be read here http://bit.ly/2tRViJ9). Because of mentioned reason, i forked the repository and rebuild some of the scripts with Babel to ES5 compliant. With these actions i achieved succesful minifying during
create-react-app build and successful runtime usage in browser.

I made this pull request so you are aware of this and hopefully browser support is improved in upcoming releases related to mentioned issue. 