### PR TITLE
Use writeInt32LE instead of writeIntLE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: "node_js"
 node_js:
+  - "11"
   - "10"
   - "9"
   - "8"

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -155,11 +155,11 @@ function pae() {
   const pieces = (parse('utf-8'))(...arguments);
 
   let accumulator = Buffer.alloc(8);
-  accumulator.writeIntLE(pieces.length);
+  accumulator.writeInt32LE(pieces.length);
 
   pieces.forEach((piece) => {
     let len = Buffer.alloc(8);
-    len.writeIntLE(Buffer.byteLength(piece));
+    len.writeInt32LE(Buffer.byteLength(piece));
 
     accumulator = Buffer.concat([ accumulator, len, piece ]);
   });


### PR DESCRIPTION
In Node 10, using writeIntLE without a length argument implies length = 1. Thus, signing a message longer than 127 bytes throws an error : 

```
async function main() {
        const key = new Paseto.SymmetricKey.V2();
        const data = Buffer.alloc(256);
        await key.generate();
        console.log(await key.protocol().sign(data, key));
}

main().catch(console.log);
```

```
RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= -128 and <= 127. Received 256
    at writeU_Int8 (internal/buffer.js:559:11)
    at Buffer.writeIntLE (internal/buffer.js:676:12)
    at pieces.forEach (/opt/data/simon/tmp/paseto.js/lib/utils.js:162:9)
    at Array.forEach (<anonymous>)
    at Object.pae (/opt/data/simon/tmp/paseto.js/lib/utils.js:160:10)
    at sodium.ready.then (/opt/data/simon/tmp/paseto.js/lib/protocol/V2.js:246:30)
```

In Node 11, it is an error (issue #6)