### PR TITLE
Fix protocol check

### DIFF
--- a/lib/key/private.js
+++ b/lib/key/private.js
@@ -51,7 +51,7 @@ function inject(rkey, cb) {
 
   return sodium.ready.then(() => {
 
-    if (protocol instanceof V2) {
+    if (self.protocol() instanceof V2) {
 
       if (!(rkey instanceof Buffer)) { return done(new TypeError('Raw key must be provided as a buffer')); }
 

--- a/lib/key/public.js
+++ b/lib/key/public.js
@@ -45,7 +45,7 @@ function inject(rkey, cb) {
 
   return sodium.ready.then(() => {
 
-    if (protocol instanceof V2) {
+    if (self.protocol() instanceof V2) {
 
       if (!(rkey instanceof Buffer)) { return done(new TypeError('Raw key must be provided as a buffer')); }
 

--- a/test/V2.test.js
+++ b/test/V2.test.js
@@ -314,11 +314,11 @@ describe('Protocol V2', () => {
       const keypair = sodium.crypto_sign_keypair();
 
       sk = new Paseto.PrivateKey.V2();
-      sk.inject(keypair.privateKey, (err) => {
+      sk.inject(Buffer.from(keypair.privateKey, 'binary'), (err) => {
         if (err) { return done(err); }
 
         pk = new Paseto.PublicKey.V2();
-        pk.inject(keypair.publicKey, done);
+        pk.inject(Buffer.from(keypair.publicKey, 'binary'), done);
       });
     });
 


### PR DESCRIPTION
The comparison is currently checking the function `protocol` against `V2` instead of the result of calling `protocol()`.