### PR TITLE
add void to callback

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -241,7 +241,7 @@ function ret(callback) {
    */
   return function() {
     const args = [ ...arguments ];
-    if (!promisify) { return callback.apply(this, args); }
+    if (!promisify) { return void callback.apply(this, args); }
 
     return new Promise((resolve, reject) => {
       const err = args.shift();


### PR DESCRIPTION
Helps garbage collection (reducing scope) and prevent misuse.